### PR TITLE
DEVOPS-781   Troubleshooting Vue script

### DIFF
--- a/preset.json
+++ b/preset.json
@@ -15,10 +15,7 @@
       "lintOn": ["save"]
     },
     "@vue/cli-plugin-unit-jest": {},
-    "@vue/cli-plugin-e2e-cypress": {},
-    "vue-cli-plugin-vuetify": {
-      "preset": "default"
-    }
+    "@vue/cli-plugin-e2e-cypress": {}
   },
   "vueVersion": "2",
   "cssPreprocessor": "dart-sass"


### PR DESCRIPTION
Removed:
```json
    "vue-cli-plugin-vuetify": {
      "preset": "default"
    }
``` 

Since Vuetify updated its preset options there is an issue when using it in a remote preset. Created an issue about it here: https://github.com/vuetifyjs/vue-cli-plugins/issues/338#issue-1435148782